### PR TITLE
Fatal Error: Function curl_strerror not defined

### DIFF
--- a/src/WebService/Http/CurlRequest.php
+++ b/src/WebService/Http/CurlRequest.php
@@ -75,7 +75,11 @@ class CurlRequest implements Request
     {
         $body = curl_exec($curl);
         if ($errno = curl_errno($curl)) {
-            $error_message = curl_strerror($errno);
+        	if (function_exists('curl_strerror'))
+            	$error_message = curl_strerror($errno);
+            else
+            	$error_message = curl_error($curl);
+
             throw new HttpException(
                 "cURL error ({$errno}): {$error_message}",
                 0,


### PR DESCRIPTION
curl_strerror was introduced in PHP 5.5, so use the older curl_error() instead if it doesn't exist.