### PR TITLE
Support timeout as float values. 

### DIFF
--- a/src/WebService/Http/CurlRequest.php
+++ b/src/WebService/Http/CurlRequest.php
@@ -64,8 +64,10 @@ class CurlRequest implements Request
         $opts[CURLOPT_HTTPHEADER] = $this->options['headers'];
         $opts[CURLOPT_USERAGENT] = $this->options['userAgent'];
 
-        $opts[CURLOPT_CONNECTTIMEOUT] = $this->options['connectTimeout'];
-        $opts[CURLOPT_TIMEOUT] = $this->options['timeout'];
+        $opts[CURLOPT_CONNECTTIMEOUT] = ceil($this->options['connectTimeout']);
+        $opts[CURLOPT_CONNECTTIMEOUT_MS] = ceil($this->options['connectTimeout'] * 1000);
+        $opts[CURLOPT_TIMEOUT] = ceil($this->options['timeout']);
+        $opts[CURLOPT_TIMEOUT_MS] = ceil($this->options['timeout'] * 1000);
 
         curl_setopt_array($curl, $opts);
         return $curl;


### PR DESCRIPTION
This needs at least cURL 7.16.2. The Constants were introduced in PHP 5.2.x so it's safe to use them here. cURL automatically ignores the integer value when the MS value is understood. 

I have tried to add a unit test but didn't know how to put it - you could do it along the lines of https://github.com/yellowtree/wp-geoip-detect/blob/master/tests/test-source-precision.php#L104