### PR TITLE
Remove development stuff from releases

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+/tests/ export-ignore
+/.* export-ignore
+/phpunit.xml.dist export-ignore


### PR DESCRIPTION
`composer require` currently downloads all the contents of the repository, but for production usage the development stuff is not required (and it could may be harmful if it contains executable files).

What about removing this development stuff from releases?

This affects only installing releases: git-cloning is not touched, so that people that want to run tests/build phars can perform a `git clone`
