### PR TITLE
MAC OS caBundle fix

### DIFF
--- a/src/WebService/Http/CurlRequest.php
+++ b/src/WebService/Http/CurlRequest.php
@@ -54,7 +54,7 @@ class CurlRequest implements Request
     {
         $curl = curl_init($this->url);
 
-        $opts[CURLOPT_CAINFO] = $this->options['caBundle'];
+        if (!empty($this->options['caBundle'])) { $opts[CURLOPT_CAINFO] = $this->options['caBundle']; }
         $opts[CURLOPT_SSL_VERIFYHOST] = 2;
         $opts[CURLOPT_FOLLOWLOCATION] = false;
         $opts[CURLOPT_SSL_VERIFYPEER] = true;


### PR DESCRIPTION
Added option to disable cacert bundle since OS X uses keychain curl to validate certs