### PR TITLE
Use more specific namespaces for autoloader

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,8 @@
   },
   "autoload": {
     "psr-4": {
-      "MaxMind\\": "src"
+      "MaxMind\\Exception\\": "src/Exception",
+      "MaxMind\\WebService\\": "src/WebService"
     }
   }
 }


### PR DESCRIPTION
to prevent namespace overlap with MaxMind-DB-Reader-php