### PR TITLE
Remove HHVM support from readme/travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ matrix:
       env:
         - RUN_LINTER=1
         - RUN_SNYK=1
-    - php: hhvm
     - php: nightly
   allow_failures:
     - php: nightly

--- a/README.md
+++ b/README.md
@@ -5,8 +5,7 @@ shared code between MaxMind's various web service client APIs.
 
 ## Requirements  ##
 
-The library requires PHP 5.4 or greater. This library works and is tested
-with HHVM.
+The library requires PHP 5.4 or greater.
 
 There are several other dependencies as defined in the `composer.json` file.
 


### PR DESCRIPTION
HHVM 4.0 is released and the version that travis runs, and it [no longer supports php](https://hhvm.com/blog/2018/09/12/end-of-php-support-future-of-hack.html).