### PR TITLE
Re-use the cURL handle when doing multiple requests to the Maxmind API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,7 @@ cache:
   directories:
     - $HOME/.composer/cache
 before_install:
-  - composer self-update
-  - composer install --dev -n --prefer-source
+  - composer install --no-interaction
   - phpenv rehash
   - "if [[ $RUN_SNYK && $SNYK_TOKEN ]]; then sudo apt-get install -y nodejs; npm install -g snyk; fi"
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,12 @@ language: php
 dist: trusty
 matrix:
   include:
-    - php: '5.4'
     - php: '5.5'
     - php: '5.6'
     - php: '7.0'
     - php: '7.1'
     - php: '7.2'
+    - php: '7.3'
       env:
         - RUN_LINTER=1
         - RUN_SNYK=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,9 @@ matrix:
     - php: nightly
   allow_failures:
     - php: nightly
+cache:
+  directories:
+    - $HOME/.composer/cache
 before_install:
   - composer self-update
   - composer install --dev -n --prefer-source

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     }
   ],
   "require": {
-    "php": ">=5.4",
+    "php": ">=5.5",
     "composer/ca-bundle": "^1.0.3",
     "ext-curl": "*",
     "ext-json": "*"

--- a/src/WebService/Http/CurlRequest.php
+++ b/src/WebService/Http/CurlRequest.php
@@ -82,7 +82,7 @@ class CurlRequest implements Request
             $opts[CURLOPT_CAINFO] = $this->options['caBundle'];
         }
 
-        $opts[CURLOPT_ENCODING]       = "";
+        $opts[CURLOPT_ENCODING] = "";
         $opts[CURLOPT_SSL_VERIFYHOST] = 2;
         $opts[CURLOPT_FOLLOWLOCATION] = false;
         $opts[CURLOPT_SSL_VERIFYPEER] = true;
@@ -115,8 +115,10 @@ class CurlRequest implements Request
 
     /**
      * @param resource $curl
-     * @return array
+     *
      * @throws HttpException
+     *
+     * @return array
      */
     private function execute($curl)
     {

--- a/src/WebService/Http/CurlRequest.php
+++ b/src/WebService/Http/CurlRequest.php
@@ -28,7 +28,7 @@ class CurlRequest implements Request
 
     /**
      * @param string $url
-     * @param array $options
+     * @param array  $options
      */
     public function __construct($url, $options)
     {
@@ -82,7 +82,7 @@ class CurlRequest implements Request
             $opts[CURLOPT_CAINFO] = $this->options['caBundle'];
         }
 
-        $opts[CURLOPT_ENCODING] = "";
+        $opts[CURLOPT_ENCODING] = '';
         $opts[CURLOPT_SSL_VERIFYHOST] = 2;
         $opts[CURLOPT_FOLLOWLOCATION] = false;
         $opts[CURLOPT_SSL_VERIFYPEER] = true;

--- a/src/WebService/Http/CurlRequest.php
+++ b/src/WebService/Http/CurlRequest.php
@@ -11,17 +11,37 @@ use MaxMind\Exception\HttpException;
  */
 class CurlRequest implements Request
 {
+    /**
+     * @var resource
+     */
+    private $ch;
+
+    /**
+     * @var string
+     */
     private $url;
+
+    /**
+     * @var array
+     */
     private $options;
 
     /**
-     * @param $url
-     * @param $options
+     * @param string $url
+     * @param array $options
      */
     public function __construct($url, $options)
     {
         $this->url = $url;
         $this->options = $options;
+    }
+
+    /**
+     * @param resource $ch
+     */
+    public function setCurlHandle($ch)
+    {
+        $this->ch = $ch;
     }
 
     /**
@@ -53,11 +73,16 @@ class CurlRequest implements Request
      */
     private function createCurl()
     {
-        $curl = curl_init($this->url);
+        curl_reset($this->ch);
+
+        $opts = [];
+        $opts[CURLOPT_URL] = $this->url;
 
         if (!empty($this->options['caBundle'])) {
             $opts[CURLOPT_CAINFO] = $this->options['caBundle'];
         }
+
+        $opts[CURLOPT_ENCODING]       = "";
         $opts[CURLOPT_SSL_VERIFYHOST] = 2;
         $opts[CURLOPT_FOLLOWLOCATION] = false;
         $opts[CURLOPT_SSL_VERIFYPEER] = true;
@@ -83,11 +108,16 @@ class CurlRequest implements Request
             $opts[CURLOPT_TIMEOUT] = ceil($timeout);
         }
 
-        curl_setopt_array($curl, $opts);
+        curl_setopt_array($this->ch, $opts);
 
-        return $curl;
+        return $this->ch;
     }
 
+    /**
+     * @param resource $curl
+     * @return array
+     * @throws HttpException
+     */
     private function execute($curl)
     {
         $body = curl_exec($curl);
@@ -103,7 +133,6 @@ class CurlRequest implements Request
 
         $statusCode = curl_getinfo($curl, CURLINFO_HTTP_CODE);
         $contentType = curl_getinfo($curl, CURLINFO_CONTENT_TYPE);
-        curl_close($curl);
 
         return [$statusCode, $contentType, $body];
     }

--- a/src/WebService/Http/RequestFactory.php
+++ b/src/WebService/Http/RequestFactory.php
@@ -9,18 +9,36 @@ namespace MaxMind\WebService\Http;
  */
 class RequestFactory
 {
+    /**
+     * Keep the cURL resource here, so that if there are multiple API requests
+     * done the connection is kept alive, SSL resumption can be used
+     * etcetera.
+     *
+     * @var resource
+     */
+    private $ch;
+
     public function __construct()
     {
+        $this->ch = curl_init();
+    }
+
+    public function __destruct()
+    {
+        curl_close($this->ch);
     }
 
     /**
      * @param $url
      * @param $options
      *
-     * @return CurlRequest
+     * @return Request
      */
     public function request($url, $options)
     {
-        return new CurlRequest($url, $options);
+        $request = new CurlRequest($url, $options);
+        $request->setCurlHandle($this->ch);
+
+        return $request;
     }
 }

--- a/tests/MaxMind/Test/WebService/Http/CurlRequestTest.php
+++ b/tests/MaxMind/Test/WebService/Http/CurlRequestTest.php
@@ -34,6 +34,7 @@ class CurlRequestTest extends \PHPUnit_Framework_TestCase
             'invalid host',
             $this->options
         );
+        $cr->setCurlHandle(curl_init());
 
         $cr->get();
     }
@@ -48,6 +49,7 @@ class CurlRequestTest extends \PHPUnit_Framework_TestCase
             'invalid host',
             $this->options
         );
+        $cr->setCurlHandle(curl_init());
 
         $cr->post('POST BODY');
     }


### PR DESCRIPTION
See https://github.com/maxmind/minfraud-api-php/issues/59.

This re-uses the cURL handle between requests, improving performance by keeping the socket alive if possible and allowing SSL session resumption.

It also enables compression (gzip) on the response by telling the server what type of encoding is supported.