### PR TITLE
Test enhancement

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -23,6 +23,7 @@ return PhpCsFixer\Config::create()
         'phpdoc_no_alias_tag' => false,
         'phpdoc_order' => true,
         'semicolon_after_instruction' => true,
+        'single_line_throw' => false,
         'strict_comparison' => true,
         'strict_param' => true,
         'yoda_style' => false,

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ matrix:
     - php: '7.0'
     - php: '7.1'
     - php: '7.2'
+    - php: '7.3'
       env:
         - RUN_LINTER=1
         - RUN_SNYK=1

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
   },
   "require-dev": {
     "friendsofphp/php-cs-fixer": "2.*",
-    "phpunit/phpunit": "4.*",
+    "phpunit/phpunit": "^4.8.36 || ^5.7 || ^6.5 || ^7.0",
     "squizlabs/php_codesniffer": "3.*"
   },
   "autoload": {

--- a/tests/MaxMind/Test/WebService/ClientTest.php
+++ b/tests/MaxMind/Test/WebService/ClientTest.php
@@ -4,11 +4,12 @@ namespace MaxMind\Test\WebService;
 
 use Composer\CaBundle\CaBundle;
 use MaxMind\WebService\Client;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @coversNothing
  */
-class ClientTest extends \PHPUnit_Framework_TestCase
+class ClientTest extends TestCase
 {
     public function test200()
     {
@@ -198,8 +199,13 @@ class ClientTest extends \PHPUnit_Framework_TestCase
         $licenseKey = '0123456789',
         $options = []
     ) {
+        $host = isset($options['host']) ? $options['host'] : 'api.maxmind.com';
+
+        $url = 'https://' . $host . $path;
+
         $stub = $this->getMockForAbstractClass(
-            'MaxMind\\WebService\\Http\\Request'
+            'MaxMind\\WebService\\Http\\Request',
+            [$url, $options]
         );
 
         $stub->expects($this->once())
@@ -210,10 +216,6 @@ class ClientTest extends \PHPUnit_Framework_TestCase
         $factory = $this->getMockBuilder(
             'MaxMind\\WebService\\Http\\RequestFactory'
         )->getMock();
-
-        $host = isset($options['host']) ? $options['host'] : 'api.maxmind.com';
-
-        $url = 'https://' . $host . $path;
 
         $headers = [
             'Content-Type: application/json',

--- a/tests/MaxMind/Test/WebService/Http/CurlRequestTest.php
+++ b/tests/MaxMind/Test/WebService/Http/CurlRequestTest.php
@@ -3,6 +3,7 @@
 namespace MaxMind\Test\WebService\Http;
 
 use MaxMind\WebService\Http\CurlRequest;
+use PHPUnit\Framework\TestCase;
 
 // These tests are totally insufficient, but they do test that most of our
 // curl calls are at least syntactically valid and available in each PHP
@@ -13,7 +14,7 @@ use MaxMind\WebService\Http\CurlRequest;
 /**
  * @coversNothing
  */
-class CurlRequestTest extends \PHPUnit_Framework_TestCase
+class CurlRequestTest extends TestCase
 {
     private $options = [
         'caBundle' => null,
@@ -26,7 +27,7 @@ class CurlRequestTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @expectedException \MaxMind\Exception\HttpException
-     * @expectedExceptionMessage cURL error (6):
+     * @expectedExceptionMessage cURL error (6): Could not resolve host: invalid host
      */
     public function testGet()
     {
@@ -40,7 +41,7 @@ class CurlRequestTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @expectedException \MaxMind\Exception\HttpException
-     * @expectedExceptionMessage cURL error (6):
+     * @expectedExceptionMessage cURL error (6): Could not resolve host: invalid host
      */
     public function testPost()
     {


### PR DESCRIPTION
# Changed log
- Defining multiple `PHPUnit` versions to support different `PHP` versions because of compatibility.
- Add the `-n` option to ignore warning message output during `phpcs` coding style check.
- Using the class-based namespace to be compatible with all `PHPUnit` verions.
- Remove the `@expectedExceptionMessage` annotation because every `cURL` version have different error message.
- The `MaxMind\\WebService\\Http\\Request` class constructor has the arguments and it adds missing arguments.