### PR TITLE
Ensure the curl handle is always set when attempting to use it

### DIFF
--- a/src/WebService/Http/RequestFactory.php
+++ b/src/WebService/Http/RequestFactory.php
@@ -30,6 +30,7 @@ class RequestFactory
         if (empty($this->ch)) {
             $this->ch = curl_init();
         }
+
         return $this->ch;
     }
 

--- a/src/WebService/Http/RequestFactory.php
+++ b/src/WebService/Http/RequestFactory.php
@@ -18,14 +18,18 @@ class RequestFactory
      */
     private $ch;
 
-    public function __construct()
-    {
-        $this->ch = curl_init();
-    }
-
     public function __destruct()
     {
-        curl_close($this->ch);
+        if (!empty($this->ch)) {
+            curl_close($this->ch);
+        }
+    }
+
+    private function getCurlHandle() {
+        if (empty($this->ch)) {
+            $this->ch = curl_init();
+        }
+        return $this->ch;
     }
 
     /**
@@ -36,7 +40,7 @@ class RequestFactory
      */
     public function request($url, $options)
     {
-        $options['curlHandle'] = $this->ch;
+        $options['curlHandle'] = $this->getCurlHandle();
 
         return new CurlRequest($url, $options);
     }

--- a/src/WebService/Http/RequestFactory.php
+++ b/src/WebService/Http/RequestFactory.php
@@ -25,7 +25,8 @@ class RequestFactory
         }
     }
 
-    private function getCurlHandle() {
+    private function getCurlHandle()
+    {
         if (empty($this->ch)) {
             $this->ch = curl_init();
         }

--- a/tests/MaxMind/Test/WebService/Http/CurlRequestTest.php
+++ b/tests/MaxMind/Test/WebService/Http/CurlRequestTest.php
@@ -33,12 +33,12 @@ class CurlRequestTest extends TestCase
 
     /**
      * @expectedException \MaxMind\Exception\HttpException
-     * @expectedExceptionMessageRegExp /^cURL error \(3\).+/
+     * @expectedExceptionMessageRegExp /^cURL error.*invalid.host/
      */
     public function testGet()
     {
         $cr = new CurlRequest(
-            'invalid host',
+            'invalid.host',
             $this->options
         );
 
@@ -47,12 +47,12 @@ class CurlRequestTest extends TestCase
 
     /**
      * @expectedException \MaxMind\Exception\HttpException
-     * @expectedExceptionMessageRegExp /^cURL error \(3\).+/
+     * @expectedExceptionMessageRegExp /^cURL error.*invalid.host/
      */
     public function testPost()
     {
         $cr = new CurlRequest(
-            'invalid host',
+            'invalid.host',
             $this->options
         );
 

--- a/tests/MaxMind/Test/WebService/Http/CurlRequestTest.php
+++ b/tests/MaxMind/Test/WebService/Http/CurlRequestTest.php
@@ -33,7 +33,7 @@ class CurlRequestTest extends TestCase
 
     /**
      * @expectedException \MaxMind\Exception\HttpException
-     * @expectedExceptionMessageRegExp /^cURL error.*invalid host/
+     * @expectedExceptionMessageRegExp /^cURL error \(3\).+/
      */
     public function testGet()
     {
@@ -47,7 +47,7 @@ class CurlRequestTest extends TestCase
 
     /**
      * @expectedException \MaxMind\Exception\HttpException
-     * @expectedExceptionMessageRegExp /^cURL error.*invalid host/
+     * @expectedExceptionMessageRegExp /^cURL error \(3\).+/
      */
     public function testPost()
     {


### PR DESCRIPTION
We were using this client in a Laravel Job (queue worker), but constructing it already when scheduling the job. When our class, containing the reference, was resolved from the service container when executing the job it had lost its reference to cUrl. Though we sh/could fix it on our side, this PR should make things a bit more robust.
Tests didn't work for me with the old regexes (even before my changes), updated the regex.