### PR TITLE
204s are acceptable response codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+0.7.0 (2020-05-05)
+------------------
+
+* Responses with a 204 status code are accepted as successes.
+
 0.6.0 (2019-12-12)
 ------------------
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,6 @@ This API uses [Semantic Versioning](http://semver.org/).
 
 ## Copyright and License ##
 
-This software is Copyright (c) 2015-2019 by MaxMind, Inc.
+This software is Copyright (c) 2015-2020 by MaxMind, Inc.
 
 This is free software, licensed under the Apache License, Version 2.0.

--- a/src/WebService/Client.php
+++ b/src/WebService/Client.php
@@ -409,8 +409,8 @@ class Client
      */
     private function handleSuccess($statusCode, $body, $service)
     {
-        $expectResponseBody = $statusCode === 204 ? false : true;
-        if (!$expectResponseBody) {
+        // A 204 should have no response body
+        if ($statusCode === 204) {
             if (\strlen($body) !== 0) {
                 throw new WebServiceException(
                     "Received a 204 response for $service along with an " .
@@ -421,6 +421,7 @@ class Client
             return '';
         }
 
+        // A 200 should have a valid JSON body
         if (\strlen($body) === 0) {
             throw new WebServiceException(
                 "Received a 200 response for $service but did not " .

--- a/src/WebService/Client.php
+++ b/src/WebService/Client.php
@@ -198,11 +198,11 @@ class Client
             $this->handle4xx($statusCode, $contentType, $responseBody, $service, $path);
         } elseif ($statusCode >= 500) {
             $this->handle5xx($statusCode, $service, $path);
-        } elseif ($statusCode !== 200) {
+        } elseif ($statusCode !== 200 && $statusCode !== 204) {
             $this->handleUnexpectedStatus($statusCode, $service, $path);
         }
 
-        return $this->handleSuccess($responseBody, $service);
+        return $this->handleSuccess($statusCode, $responseBody, $service);
     }
 
     /**
@@ -396,16 +396,31 @@ class Client
     }
 
     /**
-     * @param string $body    the successful request body
-     * @param string $service the service name
+     * @param int    $statusCode the HTTP status code
+     * @param string $body       the successful request body
+     * @param string $service    the service name
      *
-     * @throws WebServiceException if the request body cannot be decoded as
-     *                             JSON
+     * @throws WebServiceException if a response body is included but not
+     *                             expected, or is not expected but not
+     *                             included, or is expected and included
+     *                             but cannot be decoded as JSON
      *
      * @return array the decoded request body
      */
-    private function handleSuccess($body, $service)
+    private function handleSuccess($statusCode, $body, $service)
     {
+        $expectResponseBody = $statusCode === 204 ? false : true;
+        if (!$expectResponseBody) {
+            if (\strlen($body) !== 0) {
+                throw new WebServiceException(
+                    "Received a 204 response for $service along with an " .
+                    "unexpected HTTP body: $body"
+                );
+            }
+
+            return '';
+        }
+
         if (\strlen($body) === 0) {
             throw new WebServiceException(
                 "Received a 200 response for $service but did not " .

--- a/src/WebService/Client.php
+++ b/src/WebService/Client.php
@@ -418,7 +418,7 @@ class Client
                 );
             }
 
-            return '';
+            return null;
         }
 
         // A 200 should have a valid JSON body

--- a/tests/MaxMind/Test/WebService/ClientTest.php
+++ b/tests/MaxMind/Test/WebService/ClientTest.php
@@ -26,8 +26,7 @@ class ClientTest extends TestCase
 
     public function test204()
     {
-        $this->assertSame(
-            '',
+        $this->assertNull(
             $this->withResponse(
                 204,
                 'application/json',

--- a/tests/MaxMind/Test/WebService/ClientTest.php
+++ b/tests/MaxMind/Test/WebService/ClientTest.php
@@ -24,6 +24,19 @@ class ClientTest extends TestCase
         );
     }
 
+    public function test204()
+    {
+        $this->assertSame(
+            '',
+            $this->withResponse(
+                204,
+                'application/json',
+                ''
+            ),
+            'received expected empty response'
+        );
+    }
+
     public function testOptions()
     {
         $this->runRequest(
@@ -52,6 +65,15 @@ class ClientTest extends TestCase
     public function test200WithInvalidJson()
     {
         $this->withResponse(200, 'application/json', '{');
+    }
+
+    /**
+     * @expectedException \MaxMind\Exception\WebServiceException
+     * @expectedExceptionMessage Received a 204 response for TestService along with an unexpected HTTP body: non-empty response body
+     */
+    public function test204WithResponseBody()
+    {
+        $this->withResponse(204, 'application/json', 'non-empty response body');
     }
 
     /**


### PR DESCRIPTION
We are in the process of adding the Report Transactions API to the [minfraud-api-php client library](https://github.com/maxmind/minfraud-api-php). That API uses this library as its web service client, and returns 204 with no response body on success. This client library currently treats a 204 as a failure. This PR makes makes 204s treated as successes.