### PR TITLE
Fix the release script, prepare for a release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 CHANGELOG
 =========
 
-0.7.0 (2020-05-05)
+0.7.0 (2020-05-06)
 ------------------
 
 * Responses with a 204 status code are accepted as successes.

--- a/dev-bin/release.sh
+++ b/dev-bin/release.sh
@@ -20,7 +20,7 @@ fi
 
 version="${BASH_REMATCH[1]}"
 date="${BASH_REMATCH[2]}"
-notes="$(echo "${BASH_REMATCH[3]}" | sed -n -e '/^[0-9]\+\.[0-9]\+\.[0-9]\+/,$!p')"
+notes="$(echo "${BASH_REMATCH[3]}" | sed -n -E '/^[0-9]+\.[0-9]+\.[0-9]+/,$!p')"
 
 if [[ "$date" !=  $(date +"%Y-%m-%d") ]]; then
     echo "$date is not today!"


### PR DESCRIPTION
The release script uses a sed GNU-specific basic regexp matching mode (`-e`) and includes a character (the quantity modifier `+`) which is interpreted differently when run OS X. This PR modifies the release script to use `-E` for so that the release script does the right thing on platforms that have a version of sed which can use POSIXly compliant regexp.